### PR TITLE
Fix file qrs edits

### DIFF
--- a/apps/web/app/api/qrs/[qrId]/route.ts
+++ b/apps/web/app/api/qrs/[qrId]/route.ts
@@ -47,12 +47,7 @@ export const PATCH = withWorkspace(
     });
 
     const body = updateQrBodySchema.parse(await parseRequestBody(req)) || {};
-
-    const qrTypeChanged = body.qrType && body.qrType !== qr.qrType;
-    const qrTypeChangedFromFileToNonFile =
-      qrTypeChanged &&
-      FILE_QR_TYPES.includes(qr.qrType as EQRType) &&
-      !FILE_QR_TYPES.includes(body.qrType as EQRType);
+    const fileQrType = FILE_QR_TYPES.includes(body.qrType as EQRType);
 
     try {
       // Define the correct URL for the link
@@ -60,7 +55,7 @@ export const PATCH = withWorkspace(
       if (body.fileId) {
         // There is a new file - use the new URL
         linkUrl = `${R2_URL}/qrs-content/${body.fileId}`;
-      } else if (qr.fileId && !qrTypeChangedFromFileToNonFile) {
+      } else if (qr.fileId && fileQrType) {
         // There is no new file, but there is an existing file - use the existing URL
         linkUrl = `${R2_URL}/qrs-content/${qr.fileId}`;
       } else {

--- a/apps/web/ui/modals/qr-content-editor/index.tsx
+++ b/apps/web/ui/modals/qr-content-editor/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { EQRType } from "@/ui/qr-builder/constants/get-qr-config.ts";
+import { setFiles } from "@/ui/qr-builder/helpers";
 import { convertQrStorageDataToBuilderWithPartialUpdate } from "@/ui/qr-builder/helpers/data-converters.ts";
 import { qrTypeDataHandlers } from "@/ui/qr-builder/helpers/qr-type-data-handlers.ts";
 import { useQrCustomization } from "@/ui/qr-builder/hooks/use-qr-customization.ts";
@@ -131,6 +132,9 @@ export function QRContentEditorModal({
         ...(formData.filesPDF ? (formData.filesPDF as File[]) : []),
         ...(formData.filesVideo ? (formData.filesVideo as File[]) : []),
       ];
+
+      // We need to update global files
+      setFiles(files);
 
       const partialUpdate: QRPartialUpdateData = {
         title: formData.qrName as string,

--- a/apps/web/ui/qr-builder/helpers/data-converters.ts
+++ b/apps/web/ui/qr-builder/helpers/data-converters.ts
@@ -117,10 +117,10 @@ export const convertQRForUpdate = async (
 
   const titleChanged = newQRData.title !== originalQR.title;
   const qrTypeChanged = newQRData.qrType !== originalQR.qrType;
-  const qrTypeChangedFromFileToNonFile =
-    qrTypeChanged &&
-    FILE_QR_TYPES.includes(originalQR.qrType as EQRType) &&
-    !FILE_QR_TYPES.includes(newQRData.qrType as EQRType);
+  const newQrDataHasFileQrType = FILE_QR_TYPES.includes(
+    newQRData.qrType as EQRType,
+  );
+
   const frameOptionsChanged = (() => {
     const originalFrame = originalQR.frameOptions as FrameOptions;
     const newFrame = newQRData.frameOptions;
@@ -179,9 +179,7 @@ export const convertQRForUpdate = async (
   }
 
   const linkUrl =
-    hasNewFiles || (hasExistingFiles && !qrTypeChangedFromFileToNonFile)
-      ? ""
-      : newData;
+    hasNewFiles || (hasExistingFiles && newQrDataHasFileQrType) ? "" : newData;
 
   const updateData: UpdateQrProps = {
     data: newData,

--- a/apps/web/ui/qr-builder/hooks/use-qr-customization.ts
+++ b/apps/web/ui/qr-builder/hooks/use-qr-customization.ts
@@ -47,17 +47,10 @@ export function useQrCustomization(
   );
 
   const isWiFiQR = initialData?.qrType === "wifi";
-  // const isFileQR = FILE_QR_TYPES.includes(initialData?.qrType as EQRType);
 
   const initialContentForQrBuild = isWiFiQR
     ? initialData?.data
     : initialData?.link?.shortLink;
-
-  // const initialContentForQrBuild = !FILE_QR_TYPES.includes(
-  //   initialData?.qrType as EQRType,
-  // )
-  //   ? (initialData?.styles as Options)?.data
-  //   : initialData?.link?.shortLink;
 
   const [data, setData] = useState(initialContentForQrBuild || DEFAULT_WEBSITE);
 


### PR DESCRIPTION
There are several fixes:

1) Create file QR type -> Replace current file with a new file -> Customize QR -> QR leads to the first old file
2) Create file QR type -> Change QR type to link type -> Customize QR -> QR leads to file, not a link